### PR TITLE
Disabled multi-select on pack screens

### DIFF
--- a/Forms/BehaviorPackForm.Designer.cs
+++ b/Forms/BehaviorPackForm.Designer.cs
@@ -76,6 +76,7 @@
             bpInactiveListView.FullRowSelect = true;
             bpInactiveListView.GridLines = true;
             bpInactiveListView.Location = new Point(0, 0);
+            bpInactiveListView.MultiSelect = false;
             bpInactiveListView.Name = "bpInactiveListView";
             bpInactiveListView.Size = new Size(374, 397);
             bpInactiveListView.TabIndex = 0;
@@ -102,6 +103,7 @@
             bpActiveListView.FullRowSelect = true;
             bpActiveListView.GridLines = true;
             bpActiveListView.Location = new Point(0, 0);
+            bpActiveListView.MultiSelect = false;
             bpActiveListView.Name = "bpActiveListView";
             bpActiveListView.Size = new Size(370, 397);
             bpActiveListView.TabIndex = 1;

--- a/Forms/ResourcePackForm.Designer.cs
+++ b/Forms/ResourcePackForm.Designer.cs
@@ -77,6 +77,7 @@
             rpInactiveListView.FullRowSelect = true;
             rpInactiveListView.GridLines = true;
             rpInactiveListView.Location = new Point(0, 0);
+            rpInactiveListView.MultiSelect = false;
             rpInactiveListView.Name = "rpInactiveListView";
             rpInactiveListView.Size = new Size(374, 397);
             rpInactiveListView.TabIndex = 0;
@@ -103,6 +104,7 @@
             rpActiveListView.FullRowSelect = true;
             rpActiveListView.GridLines = true;
             rpActiveListView.Location = new Point(0, 0);
+            rpActiveListView.MultiSelect = false;
             rpActiveListView.Name = "rpActiveListView";
             rpActiveListView.Size = new Size(370, 397);
             rpActiveListView.TabIndex = 0;


### PR DESCRIPTION
Fixes the issue where multiple packs could be selected at once, but only the first selected would respond to context menu actions. Also fixed the issue where if a pack was activated/deactivated, it could select a neighboring pack and move it as well.